### PR TITLE
Fix audio.stop() bug

### DIFF
--- a/barneprat/blocks/sound.mjs
+++ b/barneprat/blocks/sound.mjs
@@ -27,7 +27,8 @@ class Sound extends BaseBlock {
     }
 
     stop() {
-        this.audio.stop();
+        this.audio.pause();
+        this.audio.currentTime = 0;
         this.isPlaying = false;
     }
 }


### PR DESCRIPTION
Updated the audio stop.
new Audio.stop() is not a function

now it pauses and moves start time to 0
